### PR TITLE
implemented HTTP POST upload instead of PUT

### DIFF
--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -165,25 +165,110 @@ python do_dependencytrack_upload () {
     dt_sbom_url = f"{d.getVar('DEPENDENCYTRACK_API_URL')}/v1/bom"
     dt_vex_url = f"{d.getVar('DEPENDENCYTRACK_API_URL')}/v1/vex"
 
-    headers = {
-        "Content-Type": "application/json",
-        "X-API-Key": d.getVar("DEPENDENCYTRACK_API_KEY")
-    }
+
+    # Uploading works either with method PUT and Content-Type: application/json (limited to 20MB)
+    # or with method POST and Content-Type: multipart/form-data (no limit in size).
+    # see https://docs.dependencytrack.org/usage/cicd/#cyclonedx
+    # We will use the latter, but we're working with standard libraries only 
+    # and urllib does not support multipart/form-data ootb.
+    # So we need to manually construct the body of the upload request.
+    # see https://pymotw.com/3/urllib.request/#uploading-files
+
+    import io
+    import mimetypes
+    import uuid
+
+    class MultiPartForm:
+        """Accumulate the data to be used when posting a form."""
+
+        def __init__(self):
+            self.form_fields = []
+            self.files = []
+            # Use a large random byte string to separate
+            # parts of the MIME data.
+            self.boundary = uuid.uuid4().hex.encode('utf-8')
+            return
+
+        def get_content_type(self):
+            return 'multipart/form-data; boundary={}'.format(
+                self.boundary.decode('utf-8'))
+
+        def add_field(self, name, value):
+            """Add a simple field to the form data."""
+            self.form_fields.append((name, value))
+
+        def add_file(self, fieldname, filename, fileHandle,
+                    mimetype=None):
+            """Add a file to be uploaded."""
+            body = fileHandle.read()
+            if mimetype is None:
+                mimetype = (
+                    mimetypes.guess_type(filename)[0] or
+                    'application/octet-stream'
+                )
+            self.files.append((fieldname, filename, mimetype, body))
+            return
+
+        @staticmethod
+        def _form_data(name):
+            return ('Content-Disposition: form-data; '
+                    'name="{}"\r\n').format(name).encode('utf-8')
+
+        @staticmethod
+        def _attached_file(name, filename):
+            return ('Content-Disposition: file; '
+                    'name="{}"; filename="{}"\r\n').format(
+                        name, filename).encode('utf-8')
+
+        @staticmethod
+        def _content_type(ct):
+            return 'Content-Type: {}\r\n'.format(ct).encode('utf-8')
+
+        def __bytes__(self):
+            """Return a byte-string representing the form data,
+            including attached files.
+            """
+            buffer = io.BytesIO()
+            boundary = b'--' + self.boundary + b'\r\n'
+
+            # Add the form fields
+            for name, value in self.form_fields:
+                buffer.write(boundary)
+                buffer.write(self._form_data(name))
+                buffer.write(b'\r\n')
+                buffer.write(value.encode('utf-8'))
+                buffer.write(b'\r\n')
+
+            # Add the files to upload
+            for f_name, filename, f_content_type, body in self.files:
+                buffer.write(boundary)
+                buffer.write(self._attached_file(f_name, filename))
+                buffer.write(self._content_type(f_content_type))
+                buffer.write(b'\r\n')
+                buffer.write(body)
+                buffer.write(b'\r\n')
+
+            buffer.write(b'--' + self.boundary + b'--\r\n')
+            return buffer.getvalue()
 
     bb.debug(2, f"Loading final SBOM: {sbom_path}")
     sbom = Path(sbom_path).read_text()
 
-    payload = json.dumps({
-        "project": dt_project,
-        "bom": base64.b64encode(sbom.encode()).decode('ascii')
-    }).encode()
+    form = MultiPartForm()
+    form.add_field("project", dt_project)
+    form.add_field("bom", sbom)
+    payload = bytes(form)
     bb.debug(2, f"Uploading SBOM to project {dt_project} at {dt_sbom_url}")
 
     req = urllib.request.Request(
         dt_sbom_url,
         data=payload,
-        headers=headers,
-        method="PUT")
+        headers={
+            "X-API-Key": d.getVar("DEPENDENCYTRACK_API_KEY"),
+            "Content-Type": form.get_content_type(),
+            "Content-Length": len(payload)
+        },
+        method="POST")
 
     try:
       res = urllib.request.urlopen(req)
@@ -213,17 +298,21 @@ python do_dependencytrack_upload () {
     bb.debug(2, f"Loading final patched CVEs VEX: {vex_path}")
     vex = Path(vex_path).read_text()
 
-    payload = json.dumps({
-        "project": dt_project,
-        "vex": base64.b64encode(vex.encode()).decode('ascii')
-    }).encode()
+    form = MultiPartForm()
+    form.add_field("project", dt_project)
+    form.add_field("vex", vex)
+    payload = bytes(form)
 
     bb.debug(2, f"Uploading patched CVEs VEX to project {dt_project} at {dt_vex_url}")
     req = urllib.request.Request(
         dt_vex_url,
         data=payload,
-        headers=headers,
-        method="PUT")
+        headers={
+            "X-API-Key": d.getVar("DEPENDENCYTRACK_API_KEY"),
+            "Content-Type": form.get_content_type(),
+            "Content-Length": len(payload)
+        },
+        method="POST")
 
     try:
       urllib.request.urlopen(req)


### PR DESCRIPTION
implemented HTTP POST (multipart/form-data) upload instead of PUT (application/json)

Uploading works either with method PUT and Content-Type: application/json (limited to 20MB) or with method POST and Content-Type: multipart/form-data (no limit in size) (see https://docs.dependencytrack.org/usage/cicd/#cyclonedx).